### PR TITLE
Display featured image in normal page template

### DIFF
--- a/page.php
+++ b/page.php
@@ -13,6 +13,9 @@
 get_header(); ?>
 
 	<div id="primary" class="content-area">
+
+		<?php the_post_thumbnail( 'sparkling-featured', array( 'class' => 'single-featured' )); ?>
+
 		<main id="main" class="site-main" role="main">
 
 			<?php while ( have_posts() ) : the_post(); ?>


### PR DESCRIPTION
If a page is created with featured image, it is not displayed. This commit adds the featured image on pages which use this feature.

This commit doesn't change anything for pages without featured image.
