### PR TITLE
add styling to input[type="tel"]

### DIFF
--- a/style.css
+++ b/style.css
@@ -140,6 +140,7 @@ input::-moz-focus-inner { /* Corrects inner padding and border displayed oddly i
 }
 input[type="text"],
 input[type="email"],
+input[type="tel"],
 input[type="url"],
 input[type="password"],
 input[type="search"],
@@ -150,6 +151,7 @@ textarea {
 }
 input[type="text"]:focus,
 input[type="email"]:focus,
+input[type="tel"]:focus,
 input[type="url"]:focus,
 input[type="password"]:focus,
 input[type="search"]:focus,
@@ -158,6 +160,7 @@ textarea:focus {
 }
 input[type="text"],
 input[type="email"],
+input[type="tel"],
 input[type="url"],
 input[type="password"],
 input[type="search"] {


### PR DESCRIPTION
Hello, I would like to add styling to the tel input. Contact form 7 plugin actually use this type of inputs, so they should have same appearance as rest input fields. Thank you.