### PR TITLE
Fix WP_Widget deprectation notice for 4.3.0

### DIFF
--- a/inc/widgets/widget-categories.php
+++ b/inc/widgets/widget-categories.php
@@ -9,7 +9,7 @@ class sparkling_categories extends WP_Widget
 	 function sparkling_categories(){
 
         $widget_ops = array('classname' => 'sparkling-cats','description' => esc_html__( "Sparkling Categories" ,'sparkling') );
-		    $this->WP_Widget('sparkling-cats', esc_html__('Sparkling Categories','sparkling'), $widget_ops);
+		    parent::__construct('sparkling-cats', esc_html__('Sparkling Categories','sparkling'), $widget_ops);
     }
 
     function widget($args , $instance) {

--- a/inc/widgets/widget-popular-posts.php
+++ b/inc/widgets/widget-popular-posts.php
@@ -9,7 +9,7 @@ class sparkling_popular_posts extends WP_Widget
 	 function sparkling_popular_posts(){
 
         $widget_ops = array('classname' => 'sparkling-popular-posts','description' => esc_html__( "Sparkling Popular Posts Widget", 'sparkling') );
-		    $this->WP_Widget('sparkling_popular_posts', esc_html__('Sparkling Popular Posts Widget','sparkling'), $widget_ops);
+		    parent::__construct('sparkling_popular_posts', esc_html__('Sparkling Popular Posts Widget','sparkling'), $widget_ops);
     }
 
     function widget($args , $instance) {

--- a/inc/widgets/widget-social.php
+++ b/inc/widgets/widget-social.php
@@ -9,7 +9,7 @@ class sparkling_social_widget extends WP_Widget
 	 function sparkling_social_widget(){
 
         $widget_ops = array('classname' => 'sparkling-social','description' => esc_html__( "Sparkling Social Widget" ,'sparkling') );
-		    $this->WP_Widget('sparkling-social', esc_html__('Sparkling Social Widget','sparkling'), $widget_ops);
+		    parent::__construct('sparkling-social', esc_html__('Sparkling Social Widget','sparkling'), $widget_ops);
     }
 
     function widget($args , $instance) {


### PR DESCRIPTION
The called constructor method for WP_Widget is deprecated since version 4.3.0. It is required to use parent::__construct not $this->WP_Widget now.