### PR TITLE
Add Ryan Fait's Sticky Footer

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -7,35 +7,36 @@
  * @package sparkling
  */
 ?>
-			</div><!-- close .*-inner (main-content or sidebar, depending if sidebar is used) -->
-		</div><!-- close .row -->
-	</div><!-- close .container -->
-</div><!-- close .site-content -->
-
-	<div id="footer-area">
-		<div class="container footer-inner">
-			<div class="row">
-				<?php get_sidebar( 'footer' ); ?>
-			</div>
-		</div>
-
-		<footer id="colophon" class="site-footer" role="contentinfo">
-			<div class="site-info container">
-				<div class="row">
-					<?php sparkling_social(); ?>
-					<nav role="navigation" class="col-md-6">
-						<?php sparkling_footer_links(); ?>
-					</nav>
-					<div class="copyright col-md-6">
-						<?php echo of_get_option( 'custom_footer_text', 'sparkling' ); ?>
-						<?php sparkling_footer_info(); ?>
-					</div>
-				</div>
-			</div><!-- .site-info -->
-			<div class="scroll-to-top"><i class="fa fa-angle-up"></i></div><!-- .scroll-to-top -->
-		</footer><!-- #colophon -->
-	</div>
+				</div><!-- close .*-inner (main-content or sidebar, depending if sidebar is used) -->
+			</div><!-- close .row -->
+		</div><!-- close .container -->
+	</div><!-- close .site-content -->
+	<div class="sticky-footer-push"></div>
 </div><!-- #page -->
+
+<div id="footer-area">
+	<div class="container footer-inner">
+		<div class="row">
+			<?php get_sidebar( 'footer' ); ?>
+		</div>
+	</div>
+
+	<footer id="colophon" class="site-footer" role="contentinfo">
+		<div class="site-info container">
+			<div class="row">
+				<?php sparkling_social(); ?>
+				<nav role="navigation" class="col-md-6">
+					<?php sparkling_footer_links(); ?>
+				</nav>
+				<div class="copyright col-md-6">
+					<?php echo of_get_option( 'custom_footer_text', 'sparkling' ); ?>
+					<?php sparkling_footer_info(); ?>
+				</div>
+			</div>
+		</div><!-- .site-info -->
+		<div class="scroll-to-top"><i class="fa fa-angle-up"></i></div><!-- .scroll-to-top -->
+	</footer><!-- #colophon -->
+</div>
 
 <?php wp_footer(); ?>
 

--- a/functions.php
+++ b/functions.php
@@ -241,6 +241,9 @@ function sparkling_scripts() {
   // This one is for accessibility
   wp_enqueue_script( 'sparkling-skip-link-focus-fix', get_template_directory_uri() . '/inc/js/skip-link-focus-fix.js', array(), '20140222', true );
 
+  // Sticky Footer related functions
+  wp_enqueue_script( 'sticky-footer', get_template_directory_uri() . '/inc/js/sticky-footer.js', array('jquery') );
+
   // Treaded comments
   if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
     wp_enqueue_script( 'comment-reply' );

--- a/header.php
+++ b/header.php
@@ -29,7 +29,7 @@
 </head>
 
 <body <?php body_class(); ?>>
-<div id="page" class="hfeed site">
+<div id="page" class="hfeed site sticky-footer-wrapper">
 
 	<header id="masthead" class="site-header" role="banner">
 		<nav class="navbar navbar-default" role="navigation">

--- a/inc/js/sticky-footer.js
+++ b/inc/js/sticky-footer.js
@@ -1,0 +1,9 @@
+jQuery(function($){
+  $(window).on('load resize', function(){
+    //Clear out previous set height and obtain full footer height
+    $ht = $('#footer-area').height('auto').outerHeight();
+    //Set CSS for sticky footer to work properly
+    $('.sticky-footer-wrapper').css('margin', '0 auto -' + $ht + 'px');
+    $('#footer-area, .sticky-footer-push').height($ht);
+  });
+});

--- a/style.css
+++ b/style.css
@@ -4,12 +4,12 @@ Theme URI: http://colorlib.com/wp/themes/sparkling
 Author: Colorlib
 Author URI: http://colorlib.com/
 Description: Sparkling is a clean minimal and responsive WordPress theme well suited for travel, health, business, finance, portfolio, design, art, photography, personal and any other creative websites and blogs. Developed using Bootstrap 3 that makes it mobile and tablets friendly. Theme comes with full-screen slider, social icon integration, author bio, popular posts widget and improved category widget. Sparkling incorporates latest web standards such as HTML5 and CSS3 and is SEO friendly thanks to its clean structure and codebase. It has dozens of Theme Options to change theme layout, colors, fonts, slider settings and much more. Theme is also translation and multilingual ready, compatible with WPML and is available in Spanish, French, Dutch, Polish, Russian, German, Brazilian Portuguese, Portuguese (Portugal), Persian (Iranian language), Romanian, Turkish, Bulgarian, Japanese, Lithuanian, Czech, Ukrainian, Traditional Chinese, Simplified Chinese, Indonesian, Estonian and Italian. Sparkling is a free WordPress theme with premium functionality and design. Now theme is optimized to work with bbPress, Contact Form 7, Jetpack and other popular free and premium plugins.
-Version: 1.9.4
+Version: 1.9.5
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: sparkling
 Domain Path: /languages/
-Tags: green, light, white, gray, black, one-column, two-columns, right-sidebar, fluid-layout, responsive-layout, photoblogging, left-sidebar, translation-ready, custom-background, custom-colors, custom-menu, featured-images, full-width-template, post-formats, theme-options, threaded-comments
+Tags: green, light, white, gray, black, one-column, two-columns, right-sidebar, fluid-layout, responsive-layout, photoblogging, left-sidebar, translation-ready, custom-background, custom-colors, custom-menu, featured-images, full-width-template, post-formats, theme-options, threaded-comments, sticky-footer
 
 
 This theme, like WordPress, is licensed under the GPL.
@@ -36,6 +36,7 @@ sparkling is based on Underscores http://underscores.me/, (C) 2012-2015 Automatt
 13. Footer
 14. Social icons
 15. Call For Action
+16. Sticky Footer
 */
 
 /* =Global
@@ -1404,4 +1405,24 @@ button[type=submit],
 .no-js .postform,
 .no-js table#wp-calendar {
   display: block;
+}
+
+/* =Sticky Footer
+----------------------------------------------- */
+* {
+  margin: 0;
+}
+html, body {
+  height: 100%;
+}
+/* The bottom margin is the negative value of the footer's height and
+is overridden via JavaScript to account for the user's footer content */
+.sticky-footer-wrapper {
+  min-height: 100%;
+  margin: 0 auto;
+}
+/* .sticky-footer-push must be the same height as #footer-area and is
+overridden via JavaScript to account for the user's footer content */
+#footer-area, .sticky-footer-push {
+  height: auto;
 }


### PR DESCRIPTION
This commit adds [Ryan Fait's sticky footer](http://ryanfait.com/html5-sticky-footer/) to the Sparkling theme to ensure that `#footer-area` is always displayed flush with the bottom of the page.
- Adjusted HTML to comply with sticky footer implementation
  - Moved `#footer-area` outside of `#page`
  - Applied necessary wrapper class `.sticky-footer-wrapper` to `#page`
  - Added `.sticky-footer-push` element immediately before closing `#page`
- Added sticky footer CSS
- Added and enqueued self authored JS that adjusts sticky footer CSS on `window load` and `window resize` to account for users with variable footer heights and footer height changes due to responsive layouts
- Updated theme version and tags
