### PR TITLE
Fixes content color being blue when listing posts by tag

### DIFF
--- a/style.css
+++ b/style.css
@@ -295,6 +295,7 @@ textarea {
 .main-content-area {
   margin-top: 40px;
   margin-bottom: 40px;
+  color: #333;
 }
 /* =Post styling
 ----------------------------------------------- */


### PR DESCRIPTION
When viewing posts by tag, the `@media screen .tag` rule sets the font color to navy. This rule is inside `prettyfy.css`. I fixed this by adding a more specific rule, setting the color to the `.main-content-area` rule.

Here's the problem.

![sparkling-bad](https://cloud.githubusercontent.com/assets/570314/11767920/1aeb753c-a1b5-11e5-985c-d67d530afeb2.png)

And here's the same page with the solution.
![sparkling-good](https://cloud.githubusercontent.com/assets/570314/11767922/1ccedefc-a1b5-11e5-9ef1-3c87ae2b9553.png)
