### PR TITLE
Moves Read More button markup into the if else statement

### DIFF
--- a/content.php
+++ b/content.php
@@ -36,13 +36,12 @@
 
 				<?php
 				if ( get_theme_mod( 'sparkling_excerpts' ) == 1 ) :
-					the_excerpt();
-				else :
+					the_excerpt();?>
+					<p><a class="btn btn-default read-more" href="<?php the_permalink(); ?>" title="<?php the_title_attribute(); ?>"><?php esc_html_e( 'Read More', 'sparkling' ); ?></a></p>
+				<?php else :
 					the_content();
 				endif;
 				 ?>
-
-				<p><a class="btn btn-default read-more" href="<?php the_permalink(); ?>" title="<?php the_title_attribute(); ?>"><?php esc_html_e( 'Read More', 'sparkling' ); ?></a></p>
 
 				<?php
 					wp_link_pages( array(


### PR DESCRIPTION
Currently the Read More button is added regardless of whether sparkling_excerpts is 0 (full text) or 1 (excerpt).

This pull request moves the markup responsible for adding the Read More button into the else statement so that the button is only displayed if sparkling_excerpts is set to 1.

Closes #78.


