### PR TITLE
Fixed spelling of Recommended

### DIFF
--- a/inc/welcome-screen/welcome-page-setup.php
+++ b/inc/welcome-screen/welcome-page-setup.php
@@ -20,9 +20,9 @@ function sparkling_welcome_customize_register( $wp_customize ) {
 				$wp_customize,
 				'epsilon_recomended_section',
 				array(
-					'title'                         => esc_html__( 'Recomended Actions', 'sparkling' ),
+					'title'                         => esc_html__( 'Recommended Actions', 'sparkling' ),
 					'social_text'                   => esc_html__( 'We are social :', 'sparkling' ),
-					'plugin_text'                   => esc_html__( 'Recomended Plugins :', 'sparkling' ),
+					'plugin_text'                   => esc_html__( 'Recommended Plugins :', 'sparkling' ),
 					'actions'                       => $sparkling_required_actions,
 					'plugins'                       => $customizer_recommended_plugins,
 					'theme_specific_option'         => $theme_slug . '_show_required_actions',


### PR DESCRIPTION
This corrects these two strings in translate;
https://translate.wordpress.org/projects/wp-themes/sparkling/en-ca/default?filters%5Bstatus%5D=either&filters%5Boriginal_id%5D=4936315&filters%5Btranslation_id%5D=50954303
https://translate.wordpress.org/projects/wp-themes/sparkling/en-ca/default?filters%5Bstatus%5D=either&filters%5Boriginal_id%5D=4936313&filters%5Btranslation_id%5D=50954304


Note: There's other misspellings of recommended but they're variable names and classes which are potential breaking changes so avoided those and left for Theme Developer to decide on that.